### PR TITLE
Update OpenSSL env variables for mswin builds only when necessary

### DIFF
--- a/mswin_patches/prelude.rb-ssl.patch
+++ b/mswin_patches/prelude.rb-ssl.patch
@@ -7,10 +7,10 @@ index ee78b44cc5..f9e93880fa 100644
 @@ -1,3 +1,12 @@
 +begin
 +  require 'rbconfig' unless defined?(RbConfig)
-+  ENV['SSL_CERT_FILE']  = "#{RbConfig::TOPDIR}/bin/etc/ssl/cert.pem"
-+  ENV['SSL_CERT_DIR']   = "#{RbConfig::TOPDIR}/bin/etc/ssl/certs"
-+  ENV['OPENSSL_CONF']   = "#{RbConfig::TOPDIR}/bin/etc/ssl/openssl.cnf"
-+  ENV['OPENSSL_MODULES'] = "#{RbConfig::TOPDIR}/bin/lib/ossl-modules"
++  ENV['SSL_CERT_FILE']   ||= "#{RbConfig::TOPDIR}/bin/etc/ssl/cert.pem"
++  ENV['SSL_CERT_DIR']    ||= "#{RbConfig::TOPDIR}/bin/etc/ssl/certs"
++  ENV['OPENSSL_CONF']    ||= "#{RbConfig::TOPDIR}/bin/etc/ssl/openssl.cnf"
++  ENV['OPENSSL_MODULES'] ||= "#{RbConfig::TOPDIR}/bin/lib/ossl-modules"
 +rescue LoadError => e
 +end
 +


### PR DESCRIPTION
Do not try to set those environment variables if they are already set by the user.

---

I'm writing a test for https://github.com/ruby/openssl that wants to use a custom `OPENSSL_CONF` environment variable, and it currently fails on ruby/setup-ruby mswin, seemingly because the file is not read by OpenSSL: https://github.com/rhenium/ruby-openssl/commit/140eaabb3f650590736cc818333e4f208e427d6b

I'm guessing this change would fix it, but I haven't tested it myself. Could you review?