### PR TITLE
Remove no longer necessary code to run Ruby from same folder

### DIFF
--- a/1_4_post_install_bin_files.rb
+++ b/1_4_post_install_bin_files.rb
@@ -13,15 +13,6 @@ module CopyBashScripts
       ary = Dir["#{Gem.dir}/gems/*"]
       ary.each { |d| Dir.rmdir(d) if Dir.empty?(d) }
 
-      bash_preamble = <<~BASH.strip.rstrip
-        #!
-        {
-          bindir=$(dirname "$0")
-          exec "$bindir/ruby" "-x" "$0" "$@"
-        }
-        #!/usr/bin/env ruby
-      BASH
-
       windows_script = <<~BAT
         @ECHO OFF
         @"%~dp0ruby.exe" -x "%~dpn0" %*
@@ -35,8 +26,8 @@ module CopyBashScripts
 
       # file permissions may not work on Windows, especially execute
       bash_bins.each do |fn|
-        ruby_code = File.read(fn, mode: 'rb:UTF-8').split(/^#![^\n]+ruby/,2).last.lstrip
-        File.write fn, "#{bash_preamble}\n#{ruby_code}", mode: 'wb:UTF-8'
+        str = File.read(fn, mode: 'rb:UTF-8').sub(/^#![^\n]+ruby/, '#!/usr/bin/env ruby')
+        File.write fn, str, mode: 'wb:UTF-8'
       end
 
       windows_bins = bins.select { |fn| File.extname(fn).match?(/\A\.bat|\A\.cmd/) }
@@ -45,8 +36,8 @@ module CopyBashScripts
         # 'gem' bash script doesn't exist
         bash_bin = "#{BIN_DIR}/#{File.basename fn, '.*'}"
         unless File.exist? bash_bin
-          ruby_code = File.read(fn, mode: 'rb:UTF-8').split(/^#![^\n]+ruby/,2).last.lstrip
-          File.write bash_bin, "#{bash_preamble}\n#{ruby_code}", mode: 'wb:UTF-8'
+          str = File.read(fn, mode: 'rb:UTF-8').sub(/^#![^\n]+ruby/, '#!/usr/bin/env ruby')
+          File.write bash_bin, str, mode: 'wb:UTF-8'
         end
 
         File.write fn, windows_script, mode: 'wb:UTF-8'


### PR DESCRIPTION
I saw some CI issues in https://github.com/rubygems/compact_index, where Bundler was trying to run a bash script as if it was Ruby. I tracked the code that was getting run to the preamble removed in this PR.

I started investigating, and noticed that if I upgraded RubyGems before running Bundler, then things worked just fine. That's because upgrading RubyGems would remove this bash preamble. However, RubyGems doing this did not feel right because this bash preamble is supposed to be there when Ruby is compiled with the `--enable-load-relative` option and and I think that's the case for all Windows builds.

I tracked that to the `LIBRUBY_RELATIVE` key being missing in `RbConfig::CONFIG` on mswin, and because of that, bash preambles were not being generated. Fortunately @nobu fixed that at https://github.com/ruby/ruby/commit/3aa044f10c1db1608974ba4bc282c7dd1c9db3f5, so now `rbinstall` generates bash preambles by default and correcting them here should not be necessary.